### PR TITLE
Add timer option for lazy loading comments

### DIFF
--- a/admin/class-lfc-admin.php
+++ b/admin/class-lfc-admin.php
@@ -76,7 +76,7 @@ class LFC_Admin {
 
 		global $pagenow;
 
-		if ( ( $pagenow == 'options-general.php' ) && ( in_array( $_GET['page'], array( 'lfc-settings' ) ) ) ) {
+		if ( isset($_GET['page']) && ( $pagenow == 'options-general.php' ) && ( in_array( $_GET['page'], array( 'lfc-settings' ) ) ) ) {
 
 			wp_enqueue_style(
 				$this->plugin_name,
@@ -166,7 +166,7 @@ class LFC_Admin {
 
 		global $pagenow;
 
-		if ( ( $pagenow == 'options-general.php' ) && ( in_array( $_GET['page'], array( 'lfc-settings' ) ) ) ) {
+		if ( isset($_GET['page']) && ( $pagenow == 'options-general.php' ) && ( in_array( $_GET['page'], array( 'lfc-settings' ) ) ) ) {
 
 			_e( 'Thank you for choosing Lazy FB Comments to improve your website', 'lazy-facebook-comments' );
 			echo ' | ';

--- a/admin/partials/lfc-admin-general-tab.php
+++ b/admin/partials/lfc-admin-general-tab.php
@@ -33,7 +33,7 @@
                             <option value="social" <?php selected( $options['order_by'], 'social' ); ?>>Social Ranking</option>
                             <option value="reverse_time" <?php selected( $options['order_by'], 'reverse_time' ); ?>>Oldest</option>
                             <option value="time" <?php selected( $options['order_by'], 'time' ); ?>>Newest</option>
-			</select>
+                        </select>
                         <p class="description"><?php _e('Comments will be sorted in this order. See more details', 'lazy-facebook-comments'); ?> <a href="https://developers.facebook.com/docs/plugins/comments#sorting" target="_blank"><?php _e('here', 'lazy-facebook-comments'); ?></a></p>
                     </td>
                 </tr>
@@ -43,7 +43,7 @@
                         <select class="select" type="select" name="lfc_options[color_scheme]" required>
                             <option value="light" <?php selected( $options['color_scheme'], 'light' ); ?>>Light</option>
                             <option value="dark" <?php selected( $options['color_scheme'], 'dark' ); ?>>Dark</option>
-			</select>
+                        </select>
                         <p class="description"><?php _e('Only these two color schemes are availble right now.', 'lazy-facebook-comments'); ?></p>
                     </td>
                 </tr>
@@ -57,11 +57,24 @@
                 <tr>
                     <th><?php _e('Load Comments', 'lazy-facebook-comments'); ?></th>
                     <td>
-                        <select class="select" type="select" name="lfc_options[load_on]">
+                        <select class="select" name="lfc_options[load_on]" onchange="document.getElementById('timeout_sec_tr').style.display = this.value === 'timer' ? '' : 'none';">
                             <option value="click" <?php selected( $options['load_on'], 'click' ); ?>>On Click</option>
                             <option value="scroll" <?php selected( $options['load_on'], 'scroll' ); ?>>On Scroll</option>
-			</select>
+                            <option value="timer" <?php selected( $options['load_on'], 'timer' ); ?>>On Timer</option>
+                        </select>
                         <p class="description"><?php _e('Comments will be lazy loaded using this method.', 'lazy-facebook-comments'); ?></p>
+                    </td>
+                </tr>
+                <tr id="timeout_sec_tr" style="<?php if ($options['load_on'] != 'timer') echo 'display: none'; ?>">
+                    <th><?php _e('Timer Interval', 'lazy-facebook-comments'); ?></th>
+                    <td>
+                        <select class="select" name="lfc_options[timeout_sec]">
+                            <option value="0.5" <?php selected( $options['timeout_sec'], '0.5' ); ?>>0.5 second</option>
+                            <option value="1" <?php selected( $options['timeout_sec'], '1' ); ?>>1 second</option>
+                            <option value="1.5" <?php selected( $options['timeout_sec'], '1.5' ); ?>>1.5 seconds</option>
+                            <option value="2" <?php selected( $options['timeout_sec'], '2' ); ?>>2 seconds</option>
+                        </select>
+                        <p class="description"><?php _e('Comments will be lazy loaded after this timer interval.', 'lazy-facebook-comments'); ?></p>
                     </td>
                 </tr>
                 <tr>

--- a/includes/class-lfc-activator.php
+++ b/includes/class-lfc-activator.php
@@ -39,7 +39,8 @@ class LFC_Activator {
 			'order_by'       => 'social',
 			'load_on'        => 'click',
 			'div_class'      => 'comments-area',
-			'sdk_loaded'     => 0
+			'sdk_loaded'     => 0,
+			'timeout_sec'    => 1
 		);
 
 		// If not already exist, adding values

--- a/public/class-lfc-public.php
+++ b/public/class-lfc-public.php
@@ -38,7 +38,7 @@ class LFC_Public {
 	 *
 	 * @since  2.0.0
 	 * @access private
-	 * @var    string $options Get the options saved in db.
+	 * @var    string[] $options Get the options saved in db.
 	 */
 	private $options;
 
@@ -204,12 +204,14 @@ class LFC_Public {
 	 * For on click option, we don't need any script, as we
 	 * have onClick on button itself.
 	 *
-	 * @return html
+	 * @return string
 	 */
 	private function get_load_script() {
 
 		if ( $this->options['load_on'] == 'scroll' ) {
 			return $this->scroll_script();
+		} elseif ( $this->options['load_on'] == 'timer' ) {
+			return $this->timeout_script();
 		} else {
 			return $this->click_script();
 		}
@@ -221,7 +223,7 @@ class LFC_Public {
 	 * Load fb comments sdk when user scroll down
 	 * to the comments section with id "lfc_comments"
 	 *
-	 * @return html
+	 * @return string
 	 */
 	private function scroll_script() {
 
@@ -256,6 +258,33 @@ class LFC_Public {
                 ";
 
 		return $script;
+	}
+
+	/**
+	 * Timeout script
+	 *
+	 * Load fb comments sdk a certain interval after the page has loaded
+	 *
+	 * @return string
+	 */
+	private function timeout_script() {
+
+		$interval = (int)$this->options['timeout_sec'];
+
+		// if not set, default to 1 second
+		if ( $interval == 0 )
+			$interval = 1;
+
+		// convert to milliseconds
+		$interval = $interval * 1000;
+
+		return "document.addEventListener('DOMContentLoaded', function() {
+                  window.setTimeout(function() {
+                    let lfc_div = document.getElementById('lfc_comments');
+                    lfc_div.innerHTML = '{$this->comments_area_content()}';
+                    loadLFCComments();
+                  }, {$interval});
+                });\n";
 	}
 
 	/**


### PR DESCRIPTION
I really like this plugin - it's simple and does what it's supposed to do.

I added a third option to allow loading the comments a number of seconds after the page has loaded. This fits my needs better than clicking or scrolling (which both work great).